### PR TITLE
add a skiplink to jump to the main content of the page

### DIFF
--- a/_skiplinks.css
+++ b/_skiplinks.css
@@ -1,0 +1,25 @@
+/**
+ * skip link design.
+ *
+ * @author Mark C. Prins <mprins@users.sf.net>
+ */
+ 
+#dokuwiki__content:focus {
+  /* normally this is _not done_ but we don't want a focusoutline to display on a tabindex -1 main element*/
+  outline: none;
+}
+
+.skiplink {
+  background-color: __pagename_color__;
+  border: 2px solid __header_background__;
+  display: block;
+  left: -1000em;
+  padding: 0.3em;
+  position: absolute;
+}
+
+.skiplink:focus, .skiplink:active {
+  top: 1em;
+  left: 1em;
+  color: __header_background__;
+}

--- a/main.php
+++ b/main.php
@@ -39,6 +39,11 @@ require_once(dirname(__FILE__).'/tpl_functions.php');
 
 </head>
 <body>
+
+<div id="skiplinks" class="skiplinks">
+  <a href="#dokuwiki__content" class="skiplink"><?php echo $lang['skip_to_content']; ?></a>
+</div>
+
 <?php tpl_includeFile('topheader.html') ?>
 <div id="wrapper" class='<?php echo $ACT ?>'>
   <div class="dokuwiki">
@@ -54,8 +59,8 @@ require_once(dirname(__FILE__).'/tpl_functions.php');
           <?php tpl_link(wl(),$conf['title'],'id="dokuwiki__top" accesskey="h" title="[ALT+H]"')?>
         </div>
       </div>
-    
-      <?php if(tpl_getConf('trace')) {?> 
+
+      <?php if(tpl_getConf('trace')) {?>
       <div class="breadcrumbs">
         <?php ($conf['youarehere'] != 1) ? tpl_breadcrumbs() : tpl_youarehere();?>
       </div>
@@ -68,7 +73,7 @@ require_once(dirname(__FILE__).'/tpl_functions.php');
       <?php if(!tpl_getConf('hideactions') || tpl_getConf('hideactions') && isset($_SERVER['REMOTE_USER'])) { ?>
       <div class="bar" id="bar__top">
         <div class="bar-left">
-          <?php 
+          <?php
             if(!tpl_getConf('closedwiki') || (tpl_getConf('closedwiki') && isset($_SERVER['REMOTE_USER']))) {
                 switch(tpl_getConf('wiki_actionlinks')) {
                   case('buttons'):
@@ -85,7 +90,7 @@ require_once(dirname(__FILE__).'/tpl_functions.php');
                     }
                     tpl_actionlink('edit');
                     break;
-                } 
+                }
             }
           ?>
         </div>
@@ -136,19 +141,19 @@ require_once(dirname(__FILE__).'/tpl_functions.php');
           <?php tpl_searchform() ?>
           <?php arctic_tpl_sidebar('left') ?>
         </div>
-        <main class="right_page">
+        <main class="right_page" id="dokuwiki__content" tabindex="-1">
           <?php ($notoc) ? tpl_content(false) : tpl_content() ?>
         </main>
       <?php } else { ?>
-        <main class="page">
-          <?php tpl_content()?> 
-        </main> 
+        <main class="page" id="dokuwiki__content" tabindex="-1">
+          <?php tpl_content()?>
+        </main>
       <?php } ?>
 
     <?php } elseif(tpl_getConf('sidebar') == 'right') { ?>
 
       <?php if(!arctic_tpl_sidebar_hide()) { ?>
-        <main class="left_page">
+        <main class="left_page" id="dokuwiki__content" tabindex="-1">
           <?php ($notoc) ? tpl_content(false) : tpl_content() ?>
         </main>
         <div class="right_sidebar">
@@ -156,9 +161,9 @@ require_once(dirname(__FILE__).'/tpl_functions.php');
           <?php arctic_tpl_sidebar('right') ?>
         </div>
       <?php } else { ?>
-        <main class="page">
-          <?php tpl_content() ?> 
-        </main> 
+        <main class="page" id="dokuwiki__content" tabindex="-1">
+          <?php tpl_content() ?>
+        </main>
       <?php }?>
 
     <?php } elseif(tpl_getConf('sidebar') == 'both') { ?>
@@ -168,7 +173,7 @@ require_once(dirname(__FILE__).'/tpl_functions.php');
           <?php if(tpl_getConf('search') == 'left') tpl_searchform() ?>
           <?php arctic_tpl_sidebar('left') ?>
         </div>
-        <main class="center_page">
+        <main class="center_page" id="dokuwiki__content" tabindex="-1">
           <?php ($notoc) ? tpl_content(false) : tpl_content() ?>
         </main>
         <div class="right_sidebar">
@@ -176,13 +181,13 @@ require_once(dirname(__FILE__).'/tpl_functions.php');
           <?php arctic_tpl_sidebar('right') ?>
         </div>
       <?php } else { ?>
-        <main class="page">
-          <?php tpl_content()?> 
-        </main> 
+        <main class="page" id="dokuwiki__content" tabindex="-1">
+          <?php tpl_content()?>
+        </main>
       <?php }?>
 
     <?php } elseif(tpl_getConf('sidebar') == 'none') { ?>
-      <main class="page">
+      <main class="page" id="dokuwiki__content" tabindex="-1">
         <?php tpl_content() ?>
       </main>
     <?php } ?>
@@ -207,7 +212,7 @@ require_once(dirname(__FILE__).'/tpl_functions.php');
     <?php if(!tpl_getConf('closedwiki') || (tpl_getConf('closedwiki') && isset($_SERVER['REMOTE_USER']))) { ?>
     <div class="bar" id="bar__bottom">
       <div class="bar-left">
-        <?php 
+        <?php
           switch(tpl_getConf('wiki_actionlinks')) {
             case('buttons'):
                 tpl_button('edit');
@@ -221,7 +226,7 @@ require_once(dirname(__FILE__).'/tpl_functions.php');
         ?>
       </div>
       <div class="bar-right">
-        <?php 
+        <?php
           switch(tpl_getConf('wiki_actionlinks')) {
             case('buttons'):
                 tpl_button('media');

--- a/style.ini
+++ b/style.ini
@@ -15,12 +15,13 @@ style.css         = screen
 media.css         = screen
 
 _mediaoptions.css = screen
-_admin.css		    = screen
+_admin.css        = screen
 _linkwiz.css      = screen
 _subscription.css = screen
-_mediamanager.css  = screen
+_mediamanager.css = screen
 _tabs.css         = screen
 _fileuploader.css = screen
+_skiplinks.css    = screen
 
 rtl.css           = rtl
 print.css         = print


### PR DESCRIPTION
To the benefit keyboard users.

the tabindex=-1 is a hack to make sure that focus is actually transferred to the correct part of the page so that  a next tab is within the context of the main content of the page and not the context of the page  (on some brosers such as chrome this is broken). I don't like having the focus ring appear on the `main` element as a result of this hack, so hide that using `outline:none`
