### PR TITLE
Update css for button changes in Detritus release

### DIFF
--- a/_mediamanager.css
+++ b/_mediamanager.css
@@ -368,7 +368,8 @@
     width: 50%;
 }
 
-#mediamanager__page form.meta input.button {
+#mediamanager__page form.meta input.button,
+#mediamanager__page form.meta button {
     width: auto;
 }
 

--- a/_mediaoptions.css
+++ b/_mediaoptions.css
@@ -13,6 +13,7 @@
     cursor: pointer;
 }
 
-#media__popup_content input.button {
+#media__popup_content input.button,
+#media__popup_content button {
     margin-left: 9em;
 }

--- a/arctic_design.css
+++ b/arctic_design.css
@@ -86,7 +86,9 @@ div.dokuwiki div.right_sidebar div.breadcrumbs {
 
 
 div.dokuwiki div.left_sidebar div.secedit input.button,
-div.dokuwiki div.right_sidebar div.secedit input.button {
+div.dokuwiki div.left_sidebar div.secedit button,
+div.dokuwiki div.right_sidebar div.secedit input.button,
+div.dokuwiki div.right_sidebar div.secedit button {
     float: none;
     margin: 0.1em;
 }
@@ -187,10 +189,10 @@ div.dokuwiki div.breadcrumbs {
 }
 
 /* general headline setup */
-div.dokuwiki h1, 
-div.dokuwiki h2, 
-div.dokuwiki h3, 
-div.dokuwiki h4, 
+div.dokuwiki h1,
+div.dokuwiki h2,
+div.dokuwiki h3,
+div.dokuwiki h4,
 div.dokuwiki h5 {
   color: __headline_color__;
   border-color: __border__;
@@ -248,17 +250,20 @@ div.dokuwiki div.right_sidebar form#dw__search input.edit {
 }
 
 /* Buttons */
-div.dokuwiki input.button, div.dokuwiki button.button{
+div.dokuwiki input.button, div.dokuwiki button.button,
+div.dokuwiki button{
   border-color: __form_border__;
   font-size: 100%;
 }
 
-div.dokuwiki div.secedit input.button {
+div.dokuwiki div.secedit input.button,
+div.dokuwiki div.secedit button {
   border-color: __form_border__;
   font-size: 100%;
 }
 
-div.dokuwiki .bar input.button {
+div.dokuwiki .bar input.button,
+div.dokuwiki .bar button {
   height: 24px;
 }
 

--- a/design.css
+++ b/design.css
@@ -143,6 +143,7 @@ div.dokuwiki textarea.edit[readonly],
 div.dokuwiki input.edit[disabled],
 div.dokuwiki input.edit[readonly],
 div.dokuwiki input.button[disabled],
+div.dokuwiki button[disabled],
 div.dokuwiki select.edit[disabled] {
   background-color: __background_neu__!important;
   color: __text_neu__!important;
@@ -191,7 +192,8 @@ div.dokuwiki form#dw__editform div.license {
 /* --------- buttons ------------------- */
 
 div.dokuwiki input.button,
-div.dokuwiki button.button {
+div.dokuwiki button.button,
+div.dokuwiki button, {
   border: 1px solid __border__;
   color: __text__;
   background-color: __background__;
@@ -205,16 +207,18 @@ div.dokuwiki button.button {
 
 /* nice alphatransparency background except for IE <7 */
 html>body div.dokuwiki input.button,
-html>body div.dokuwiki button.button {
+html>body div.dokuwiki button.button,
+html>body div.dokuwiki button {
   background:  __background__ url(images/buttonshadow.png) repeat-x bottom;
 }
 
 * html div.dokuwiki input.button,
-* html div.dokuwiki button.button {
+* html div.dokuwiki button.button,
+* html div.dokuwiki button {
   height: 1.8em;
 }
-
-div.dokuwiki div.secedit input.button {
+div.dokuwiki div.secedit input.button,
+div.dokuwiki div.secedit button {
   border: 1px solid __border__;
   color: __text__;
   background-color: __background__;

--- a/rtl.css
+++ b/rtl.css
@@ -67,7 +67,8 @@ div.dokuwiki a.mediafile {
   padding-right: 18px;
 }
 
-div.dokuwiki div.secedit input.button {
+div.dokuwiki div.secedit input.button,
+div.dokuwiki div.secedit button {
   float: left;
 }
 

--- a/template.info.txt
+++ b/template.info.txt
@@ -1,7 +1,7 @@
 base     arctic
 author   Samuel Fischer
 email    sf@notomorrow.de
-date     2014-10-30
+date     2015-08-19
 name     Arctic Template
 desc     Yet Another Sidebar Template
 url      https://www.dokuwiki.org/template:arctic


### PR DESCRIPTION
Detritus changed all `input` button elements to `button` elements in PR splitbrain/dokuwiki#1231 This will restore our styling

close #11 